### PR TITLE
Update udt-itf-theme.gemspec

### DIFF
--- a/udt-itf-theme.gemspec
+++ b/udt-itf-theme.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "jekyll-data"
   spec.add_runtime_dependency "jekyll-gzip"
   spec.add_runtime_dependency "jekyll-redirect-from"
-  spec.add_runtime_dependency "jekyll-liquify"
+  spec.add_runtime_dependency "jekyll-liquify", "= 0.0.2"
   spec.add_runtime_dependency "rake"
 end


### PR DESCRIPTION
Pin liquify version to 0.02.  
0.0.3 generates "an uninitialized constant LiquidFilter (NameError)" during builds